### PR TITLE
🧑‍💻 chore(ci): simplify release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,24 +1,13 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"
 no-changes-template: "- No changes"
 
-categories:
-  - title: "Documentation"
-    labels: ["documentation"]
-  - title: "New Features"
-    labels: ["enhancement"]
-  - title: "Bug Fixes"
-    labels: ["bug"]
-
 template: |
+  ## Changes
+
   $CHANGES
 
   ## Contributors
-  $CONTRIBUTORS
 
-autolabeler:
-  - label: "documentation"
-    files: ["**/*.md"]
-  - label: "enhancement"
-    files: ["src/**/*"]
-  - label: "bug"
-    files: ["tests/**/*"]
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,15 +3,12 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  pull_request_target:
-    types: [edited, opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6


### PR DESCRIPTION
Remove autolabeler and categories - just list merged PRs without automatic labeling. Removes pull_request_target trigger since autolabeling is no longer needed, fixing 403 permission errors.