### PR TITLE
✨ feat: add disabled plugin visualization and filtering

### DIFF
--- a/src/lazyclaude/app.py
+++ b/src/lazyclaude/app.py
@@ -39,6 +39,7 @@ class LazyClaude(App):
         Binding("u", "filter_user", "User"),
         Binding("p", "filter_project", "Project"),
         Binding("P", "filter_plugin", "Plugin"),
+        Binding("d", "toggle_plugin_enabled_filter", "Disabled"),
         Binding("/", "search", "Search"),
         Binding("[", "prev_view", "[", show=True),
         Binding("]", "next_view", "]", show=True),
@@ -72,6 +73,7 @@ class LazyClaude(App):
         self._customizations: list[Customization] = []
         self._level_filter: ConfigLevel | None = None
         self._search_query: str = ""
+        self._plugin_enabled_filter: bool | None = True
         self._panels: list[TypePanel] = []
         self._status_panel: StatusPanel | None = None
         self._main_pane: MainPane | None = None
@@ -129,6 +131,7 @@ class LazyClaude(App):
             self._customizations,
             query=self._search_query,
             level=self._level_filter,
+            plugin_enabled=self._plugin_enabled_filter,
         )
 
     def _update_subtitle(self) -> None:
@@ -142,6 +145,9 @@ class LazyClaude(App):
             parts.append("Plugin Level")
         else:
             parts.append("All Levels")
+
+        if self._plugin_enabled_filter is True:
+            parts.append("Enabled Only")
 
         if self._search_query:
             parts.append(f'Search: "{self._search_query}"')
@@ -319,6 +325,19 @@ class LazyClaude(App):
         self._update_panels()
         self._update_subtitle()
         self._update_status_filter("Plugin")
+
+    def action_toggle_plugin_enabled_filter(self) -> None:
+        """Toggle between enabled-only and showing all plugins."""
+        if self._plugin_enabled_filter is True:
+            self._plugin_enabled_filter = None
+        else:
+            self._plugin_enabled_filter = True
+
+        self._last_focused_panel = None
+        if self._main_pane:
+            self._main_pane.customization = None
+        self._update_panels()
+        self._update_subtitle()
 
     def _update_status_filter(self, level: str) -> None:
         """Update status panel filter level and path display."""

--- a/src/lazyclaude/models/customization.py
+++ b/src/lazyclaude/models/customization.py
@@ -89,6 +89,7 @@ class PluginInfo:
     version: str  # e.g., "1.3.1"
     install_path: Path
     is_local: bool = False
+    is_enabled: bool = True
 
 
 @dataclass
@@ -116,7 +117,10 @@ class Customization:
     def display_name(self) -> str:
         """Name for display in UI, with level indicator or plugin prefix."""
         if self.plugin_info:
-            return f"[dim]{self.plugin_info.short_name}:[/]{self.name}"
+            base = f"[dim]{self.plugin_info.short_name}:[/]{self.name}"
+            if not self.plugin_info.is_enabled:
+                return f"[dim]{base}[/]"
+            return base
         level_indicator = {
             ConfigLevel.USER: "[U]",
             ConfigLevel.PROJECT: "[P]",

--- a/src/lazyclaude/services/discovery.py
+++ b/src/lazyclaude/services/discovery.py
@@ -244,10 +244,10 @@ class ConfigDiscoveryService(IConfigDiscoveryService):
         return customizations
 
     def _discover_plugins(self) -> list[Customization]:
-        """Discover customizations from installed and enabled plugins."""
+        """Discover customizations from ALL installed plugins (enabled and disabled)."""
         customizations: list[Customization] = []
 
-        for plugin_info in self._plugin_loader.get_enabled_plugins():
+        for plugin_info in self._plugin_loader.get_all_plugins():
             install_path = plugin_info.install_path
 
             for config in SCAN_CONFIGS.values():

--- a/src/lazyclaude/services/filter.py
+++ b/src/lazyclaude/services/filter.py
@@ -18,6 +18,7 @@ class IFilterService(ABC):
         customizations: list[Customization],
         query: str = "",
         level: ConfigLevel | None = None,
+        plugin_enabled: bool | None = None,
     ) -> list[Customization]:
         """
         Filter customizations by search query and/or level.
@@ -26,6 +27,7 @@ class IFilterService(ABC):
             customizations: Source list to filter.
             query: Search string (matches name only).
             level: Optional level filter (None = all levels).
+            plugin_enabled: Optional plugin enabled filter (None = both, True = enabled only, False = disabled only).
 
         Returns:
             Filtered list maintaining original order.
@@ -59,12 +61,20 @@ class FilterService(IFilterService):
         customizations: list[Customization],
         query: str = "",
         level: ConfigLevel | None = None,
+        plugin_enabled: bool | None = None,
     ) -> list[Customization]:
         """Filter customizations by search query and/or level."""
         result = customizations
 
         if level is not None:
             result = [c for c in result if c.level == level]
+
+        if plugin_enabled is not None:
+            result = [
+                c
+                for c in result
+                if c.plugin_info is None or c.plugin_info.is_enabled == plugin_enabled
+            ]
 
         if query:
             query_lower = query.lower()

--- a/src/lazyclaude/services/plugin_loader.py
+++ b/src/lazyclaude/services/plugin_loader.py
@@ -55,6 +55,18 @@ class PluginLoader:
 
         return plugins
 
+    def get_all_plugins(self) -> list[PluginInfo]:
+        """Get list of ALL plugin infos (enabled and disabled) with resolved install paths."""
+        registry = self.load_registry()
+        plugins: list[PluginInfo] = []
+
+        for plugin_id, plugin_data in registry.installed.items():
+            plugin_info = self._create_plugin_info(plugin_id, plugin_data)
+            if plugin_info and plugin_info.install_path.is_dir():
+                plugins.append(plugin_info)
+
+        return plugins
+
     def refresh(self) -> None:
         """Clear cached registry to force reload."""
         self._registry = None
@@ -88,10 +100,15 @@ class PluginLoader:
             ):
                 install_path = short_name_path
 
+        is_enabled = True
+        if self._registry:
+            is_enabled = self._registry.enabled.get(plugin_id, True)
+
         return PluginInfo(
             plugin_id=plugin_id,
             short_name=short_name,
             version=plugin_data.get("version", "unknown"),
             install_path=install_path,
             is_local=plugin_data.get("isLocal", False),
+            is_enabled=is_enabled,
         )

--- a/src/lazyclaude/widgets/detail_pane.py
+++ b/src/lazyclaude/widgets/detail_pane.py
@@ -103,6 +103,22 @@ class MainPane(Widget):
             f"[dim]Level:[/] {c.level_label}",
             f"[dim]Path:[/] {c.path}",
         ]
+
+        if c.plugin_info:
+            status = (
+                "[green]Enabled[/]"
+                if c.plugin_info.is_enabled
+                else "[yellow]Disabled[/]"
+            )
+            lines.extend(
+                [
+                    "",
+                    f"[dim]Plugin:[/] {c.plugin_info.plugin_id}",
+                    f"[dim]Version:[/] {c.plugin_info.version}",
+                    f"[dim]Status:[/] {status}",
+                ]
+            )
+
         if c.description:
             lines.append(f"[dim]Description:[/] {c.description}")
         if c.has_error:

--- a/tests/integration/discovery/test_plugins.py
+++ b/tests/integration/discovery/test_plugins.py
@@ -30,7 +30,7 @@ class TestPluginDiscovery:
         assert plugin_cmd.plugin_info is not None
         assert plugin_cmd.plugin_info.plugin_id == "example-plugin@test"
 
-    def test_disabled_plugins_excluded(
+    def test_disabled_plugins_included(
         self,
         full_user_config: Path,
         fake_project_root: Path,
@@ -40,7 +40,7 @@ class TestPluginDiscovery:
         fs.create_dir(disabled_plugin_dir / "commands")
         fs.create_file(
             disabled_plugin_dir / "commands" / "disabled-cmd.md",
-            contents="---\ndescription: Should not appear\n---\n# Disabled",
+            contents="---\ndescription: Should appear but marked as disabled\n---\n# Disabled",
         )
 
         service = ConfigDiscoveryService(
@@ -51,7 +51,9 @@ class TestPluginDiscovery:
         commands = service.discover_by_type(CustomizationType.SLASH_COMMAND)
 
         disabled_cmds = [c for c in commands if "disabled-cmd" in c.name]
-        assert len(disabled_cmds) == 0
+        assert len(disabled_cmds) == 1
+        assert disabled_cmds[0].plugin_info is not None
+        assert disabled_cmds[0].plugin_info.is_enabled is False
 
     def test_plugin_subagents_discovered(
         self,


### PR DESCRIPTION
Add support for visualizing and filtering disabled plugins in the UI:
- Disabled plugins now appear in the list view with dimmed styling
- New 'd' keybinding toggles between showing enabled-only (default) and all plugins
- Subtitle displays "Enabled Only" when filtering out disabled plugins
- Detail pane shows plugin status with color coding (green/yellow)
- Plugin enabled/disabled state tracked via PluginInfo.is_enabled field
- Filter applies at all levels (user, project, plugin, and "all")
- Non-plugin customizations always visible regardless of plugin filter

Implementation details:
- Extended PluginLoader with get_all_plugins() to load all installed plugins
- Updated discovery service to discover all plugins instead of just enabled
- Enhanced FilterService with plugin_enabled parameter for filtering logic
- Modified display_name property to dim disabled plugins
- Updated test to verify disabled plugins are included with correct state

Resolves #6