### PR TITLE
✨ feat: add less-like page scroll bindings (d/u) to MainPane

### DIFF
--- a/src/lazyclaude/widgets/detail_pane.py
+++ b/src/lazyclaude/widgets/detail_pane.py
@@ -41,6 +41,8 @@ class MainPane(Widget):
         Binding("k", "scroll_up", "Scroll up", show=False),
         Binding("down", "scroll_down", "Scroll down", show=False),
         Binding("up", "scroll_up", "Scroll up", show=False),
+        Binding("d", "scroll_page_down", "Page down", show=False),
+        Binding("u", "scroll_page_up", "Page up", show=False),
         Binding("g", "scroll_top", "Scroll top", show=False),
         Binding(
             "G", "scroll_bottom", "Scroll bottom", show=False, key_display="shift+g"
@@ -315,3 +317,11 @@ class MainPane(Widget):
     def action_scroll_bottom(self) -> None:
         """Scroll to bottom."""
         self.scroll_end(animate=False)
+
+    def action_scroll_page_down(self) -> None:
+        """Scroll page down."""
+        self.scroll_page_down(animate=False)
+
+    def action_scroll_page_up(self) -> None:
+        """Scroll page up."""
+        self.scroll_page_up(animate=False)


### PR DESCRIPTION
Add vim/less-style page scrolling for improved content navigation:
- d: scroll page down
- u: scroll page up

Complements existing j/k line scrolling and g/G top/bottom navigation.
