### PR TITLE
✨ feat: disable fancy crash screen, show simple traceback by default

### DIFF
--- a/src/lazyclaude/app.py
+++ b/src/lazyclaude/app.py
@@ -101,7 +101,7 @@ class LazyClaude(App):
         """Print simple traceback instead of Rich's fancy one."""
         self.bell()
         traceback.print_exc()
-        self._close_messages_no_wait()
+        self.exit()
 
     def compose(self) -> ComposeResult:
         """Compose the application layout."""


### PR DESCRIPTION
Override _fatal_error() to use Python's built-in traceback.print_exc() instead of Rich's formatted crash screen for better debugging during development.