### PR TITLE
🐛 fix(ui): truncate long item names with ellipsis instead of hiding

### DIFF
--- a/src/lazyclaude/styles/app.tcss
+++ b/src/lazyclaude/styles/app.tcss
@@ -59,6 +59,8 @@ TypePanel .items-container {
 TypePanel .item {
     height: 1;
     width: 100%;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
 }
 
 TypePanel .item-selected {
@@ -99,6 +101,8 @@ CombinedPanel .items-container {
 CombinedPanel .item {
     height: 1;
     width: 100%;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
 }
 
 CombinedPanel .item-selected {

--- a/src/lazyclaude/widgets/combined_panel.py
+++ b/src/lazyclaude/widgets/combined_panel.py
@@ -77,6 +77,8 @@ class CombinedPanel(Widget):
     CombinedPanel .item {
         height: 1;
         width: 100%;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
     }
 
     CombinedPanel .item-selected {

--- a/src/lazyclaude/widgets/type_panel.py
+++ b/src/lazyclaude/widgets/type_panel.py
@@ -65,6 +65,8 @@ class TypePanel(Widget):
     TypePanel .item {
         height: 1;
         width: 100%;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
     }
 
     TypePanel .item-selected {


### PR DESCRIPTION
Add text-wrap: nowrap and text-overflow: ellipsis CSS properties to .item class in TypePanel and CombinedPanel. This fixes issue #28 where long plugin skill names like "structured-plan-mode" would disappear completely instead of showing truncated with "..." indicator.

Closes #28