### PR TITLE
🐛 fix(marketplace): resolve Enter key conflict in search and preserve state

### DIFF
--- a/src/lazyclaude/app.py
+++ b/src/lazyclaude/app.py
@@ -847,7 +847,7 @@ class LazyClaude(App):
         self._plugin_preview_mode = True
 
         if self._marketplace_modal:
-            self._marketplace_modal.hide()
+            self._marketplace_modal.hide(preserve_state=True)
 
         self._update_panels()
         self._update_subtitle()
@@ -902,7 +902,7 @@ class LazyClaude(App):
             self._main_pane.customization = None
 
         if self._marketplace_modal:
-            self._marketplace_modal.show()
+            self._marketplace_modal.show(preserve_state=True)
 
     def action_exit_preview(self) -> None:
         """Exit plugin preview mode (visible binding for Esc in preview)."""

--- a/src/lazyclaude/widgets/marketplace_modal.py
+++ b/src/lazyclaude/widgets/marketplace_modal.py
@@ -26,8 +26,7 @@ class MarketplaceModal(Widget):
         Binding("p", "preview_plugin", "Preview", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
-        Binding("enter", "select_node", "Select", show=False, priority=True),
-        Binding("space", "select_node", "Toggle", show=False),
+        Binding("space", "toggle_node", "Toggle", show=False),
         Binding("right", "expand_node", "Expand", show=False),
         Binding("l", "expand_node", "Expand", show=False),
         Binding("left", "collapse_node", "Collapse", show=False),
@@ -169,7 +168,7 @@ class MarketplaceModal(Widget):
                 )
         elif isinstance(data, Marketplace):
             footer.update(
-                "[bold]Enter[/] Expand  [bold]u[/] Update  "
+                "[bold]Space[/] Toggle  [bold]u[/] Update  "
                 "[bold]/[/] Search  [bold]Esc[/] Close"
             )
         else:
@@ -179,21 +178,23 @@ class MarketplaceModal(Widget):
         """Set the marketplace loader."""
         self._loader = loader
 
-    def show(self) -> None:
+    def show(self, preserve_state: bool = False) -> None:
         """Show the modal and load marketplace data."""
-        self._load_data()
-        self._build_tree()
+        if not preserve_state:
+            self._load_data()
+            self._build_tree()
         self.add_class("visible")
         if self._tree:
             self._tree.focus()
 
-    def hide(self) -> None:
+    def hide(self, preserve_state: bool = False) -> None:
         """Hide the modal."""
         self.remove_class("visible")
-        self._filter_query = ""
-        if self._filter_input:
-            self._filter_input.clear()
-            self._filter_input.hide()
+        if not preserve_state:
+            self._filter_query = ""
+            if self._filter_input:
+                self._filter_input.clear()
+                self._filter_input.hide()
 
     def _load_data(self) -> None:
         """Load marketplace data from the loader."""
@@ -395,15 +396,9 @@ class MarketplaceModal(Widget):
         if self._tree:
             self._tree.action_cursor_up()
 
-    def action_select_node(self) -> None:
-        """Toggle node expansion or preview plugin."""
-        if not self._tree:
-            return
-
-        node = self._tree.cursor_node
-        if node and isinstance(node.data, MarketplacePlugin):
-            self.post_message(self.PluginPreview(node.data))
-        else:
+    def action_toggle_node(self) -> None:
+        """Toggle node expansion."""
+        if self._tree:
             self._tree.action_select_cursor()
 
     def action_expand_node(self) -> None:


### PR DESCRIPTION
## Summary

- Remove Enter binding that conflicted with search input submission in marketplace modal
- Add `preserve_state` parameter to `show()`/`hide()` methods to maintain modal state when navigating to/from plugin preview
- Update footer hint to show Space for toggle instead of Enter

## Changes

**marketplace_modal.py:**
- Remove `enter` binding (was conflicting with FilterInput's Enter handling)
- Rename `action_select_node` → `action_toggle_node` (Space key only)
- Update footer text: "Space Toggle" instead of "Enter Expand"
- Add `preserve_state` parameter to `show()` and `hide()` methods

**app.py:**
- Use `hide(preserve_state=True)` when entering plugin preview
- Use `show(preserve_state=True)` when exiting plugin preview

## Test plan

- [x] Open marketplace modal (Shift+M)
- [x] Press `/` to search, type query, press Enter - search should submit
- [x] Navigate to a plugin and press `p` to preview
- [x] Press Esc to return - cursor position and filter should be preserved
- [x] Press Space on marketplace node - should toggle expand/collapse

Fixes #50