### PR TITLE
✨ feat(marketplace): add plugin update action with context-aware u key

### DIFF
--- a/src/lazyclaude/app.py
+++ b/src/lazyclaude/app.py
@@ -1099,6 +1099,15 @@ class LazyClaude(App):
         cmd = ["claude", "plugin", "marketplace", "update", marketplace.entry.name]
         self._run_plugin_command(cmd, f"Updated {marketplace.entry.name}")
 
+    def on_marketplace_modal_plugin_update(
+        self, message: MarketplaceModal.PluginUpdate
+    ) -> None:
+        """Handle plugin update request."""
+        plugin = message.plugin
+        self.notify(f"Updating {plugin.name}...", severity="information")
+        cmd = ["claude", "plugin", "update", plugin.full_plugin_id]
+        self._run_plugin_command(cmd, f"Updated {plugin.name}")
+
     def on_marketplace_modal_modal_closed(
         self,
         message: MarketplaceModal.ModalClosed,  # noqa: ARG002

--- a/src/lazyclaude/widgets/marketplace_modal.py
+++ b/src/lazyclaude/widgets/marketplace_modal.py
@@ -120,6 +120,13 @@ class MarketplaceModal(Widget):
             self.plugin = plugin
             super().__init__()
 
+    class PluginUpdate(Message):
+        """Emitted when user requests to update a plugin."""
+
+        def __init__(self, plugin: MarketplacePlugin) -> None:
+            self.plugin = plugin
+            super().__init__()
+
     def __init__(
         self,
         name: str | None = None,
@@ -158,8 +165,8 @@ class MarketplaceModal(Widget):
             if data.is_installed:
                 action = "Enable" if not data.is_enabled else "Disable"
                 footer.update(
-                    f"[bold]p[/] Preview  [bold]i[/] {action}  [bold]d[/] Uninstall  "
-                    "[bold]e[/] Open  [bold]/[/] Search  [bold]Esc[/] Close"
+                    f"[bold]p[/] Preview  [bold]i[/] {action}  [bold]u[/] Update  "
+                    "[bold]d[/] Uninstall  [bold]e[/] Open  [bold]/[/] Search  [bold]Esc[/] Close"
                 )
             else:
                 footer.update(
@@ -361,7 +368,7 @@ class MarketplaceModal(Widget):
             self.post_message(self.OpenPluginFolder(data))
 
     def action_update_marketplace(self) -> None:
-        """Update the selected marketplace."""
+        """Update the selected marketplace or plugin."""
         if not self._tree:
             return
 
@@ -372,6 +379,8 @@ class MarketplaceModal(Widget):
         data = node.data
         if isinstance(data, Marketplace):
             self.post_message(self.MarketplaceUpdate(data))
+        elif isinstance(data, MarketplacePlugin) and data.is_installed:
+            self.post_message(self.PluginUpdate(data))
 
     def action_preview_plugin(self) -> None:
         """Preview the selected plugin's customizations."""


### PR DESCRIPTION
The u key now updates both marketplaces and plugins based on context:
- On marketplace node: updates marketplace (existing behavior)
- On installed plugin node: runs `claude plugin update <plugin_id>`

Footer updated to show update option for installed plugins.