### PR TITLE
Display plugin versions with update indicators in marketplace

### DIFF
--- a/src/lazyclaude/models/marketplace.py
+++ b/src/lazyclaude/models/marketplace.py
@@ -36,6 +36,7 @@ class MarketplacePlugin:
     is_installed: bool = False
     is_enabled: bool = True
     install_path: Path | None = None
+    installed_version: str | None = None
     extra_metadata: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/lazyclaude/services/marketplace_loader.py
+++ b/src/lazyclaude/services/marketplace_loader.py
@@ -25,6 +25,7 @@ class MarketplaceLoader:
         self._installed_plugin_ids: set[str] | None = None
         self._enabled_plugin_ids: set[str] | None = None
         self._install_paths: dict[str, Path] | None = None
+        self._installed_versions: dict[str, str] | None = None
         self._marketplaces_cache: list[Marketplace] | None = None
 
     def load_marketplaces(self) -> list[Marketplace]:
@@ -120,6 +121,7 @@ class MarketplaceLoader:
             source = source.get("url", str(source))
 
         install_path = (self._install_paths or {}).get(full_id)
+        installed_version = (self._installed_versions or {}).get(full_id)
 
         return MarketplacePlugin(
             name=name,
@@ -130,6 +132,7 @@ class MarketplaceLoader:
             is_installed=is_installed,
             is_enabled=is_enabled if is_installed else True,
             install_path=install_path,
+            installed_version=installed_version,
             extra_metadata={
                 k: v
                 for k, v in data.items()
@@ -169,13 +172,16 @@ class MarketplaceLoader:
                 | enabled_in_local
             )
             self._install_paths = {}
+            self._installed_versions = {}
             for pid, installations in registry.installed.items():
                 if installations:
                     self._install_paths[pid] = Path(installations[0].install_path)
+                    self._installed_versions[pid] = installations[0].version
         else:
             self._installed_plugin_ids = set()
             self._enabled_plugin_ids = set()
             self._install_paths = {}
+            self._installed_versions = {}
 
     def get_plugin_source_dir(self, plugin: MarketplacePlugin) -> Path | None:
         """Get the source directory for a plugin (installed or from marketplace)."""
@@ -225,6 +231,7 @@ class MarketplaceLoader:
         self._installed_plugin_ids = None
         self._enabled_plugin_ids = None
         self._install_paths = None
+        self._installed_versions = None
         self._marketplaces_cache = None
         if self._plugin_loader:
             self._plugin_loader._registry = None


### PR DESCRIPTION
## Summary
Adds plugin version display to the marketplace browser with visual indicators when updates are available.

## Changes
- Added `installed_version` field to `MarketplacePlugin` model
- Extended `MarketplaceLoader` to track and populate installed versions from `installed_plugins.json`
- Implemented version comparison helpers in `MarketplaceModal`:
  - `_is_semver()` - validates semantic versioning format
  - `_parse_version()` - converts version strings to comparable tuples
  - `_has_update()` - determines if update is available
- Updated plugin label rendering to show:
  - Update available: `[I] handbook (1.3.1 → 1.19.0) ↑`
  - Up to date: `[I] handbook (1.19.0)`
  - Non-semver (git hashes): `[I] dev-browser (82b390a6e17b)`

## Test plan
- [x] Open marketplace browser with `M`
- [x] Verify installed plugins show current version
- [x] Verify plugins with available updates show arrow notation and ↑ indicator
- [x] Verify plugins without updates show only current version
- [x] Verify git hash versions display without comparison
- [x] Verify non-installed plugins show no version
- [x] All pre-commit checks pass (ruff, mypy)